### PR TITLE
[SOCIAL-787] Fix ConcurrentModificationException in onMessage

### DIFF
--- a/src/main/java/org/phoenixframework/channels/Channel.java
+++ b/src/main/java/org/phoenixframework/channels/Channel.java
@@ -65,7 +65,7 @@ public class Channel {
             @Override
             public void onMessage(Envelope envelope) {
                 Channel.this.state = ChannelState.CLOSED;
-                Channel.this.socket.remove(Channel.this);
+                // Do not remove from the socket here, we will throw a CME
             }
         });
         this.onError(new IErrorCallback() {

--- a/src/main/java/org/phoenixframework/channels/Socket.java
+++ b/src/main/java/org/phoenixframework/channels/Socket.java
@@ -55,7 +55,7 @@ public class Socket {
 
             try {
                 final Envelope envelope = objectMapper.readValue(text, Envelope.class);
-                synchronized (channels) {
+                synchronized (channelLock) {
                     for (final Channel channel : channels) {
                         if (channel.isMember(envelope.getTopic())) {
                             channel.trigger(envelope.getEvent(), envelope);
@@ -119,6 +119,8 @@ public class Socket {
     public static final int RECONNECT_INTERVAL_MS = 5000;
 
     private static final int DEFAULT_HEARTBEAT_INTERVAL = 7000;
+
+    private final Object channelLock = new Object();
 
     private final List<Channel> channels = new ArrayList<>();
 
@@ -216,7 +218,7 @@ public class Socket {
     public Channel chan(final String topic, final JsonNode payload) {
         log.trace("chan: {}, {}", topic, payload);
         final Channel channel = new Channel(topic, payload, Socket.this);
-        synchronized (channels) {
+        synchronized (channelLock) {
             channels.add(channel);
         }
         return channel;
@@ -340,8 +342,9 @@ public class Socket {
      * @param channel The channel to be removed
      */
     public void remove(final Channel channel) {
-        synchronized (channels) {
-            for (final Iterator chanIter = channels.iterator(); chanIter.hasNext(); ) {
+        synchronized (channelLock) {
+            final Iterator chanIter = channels.iterator();
+            while (chanIter.hasNext()) {
                 if (chanIter.next() == channel) {
                     chanIter.remove();
                     break;
@@ -351,8 +354,12 @@ public class Socket {
     }
 
     public void removeAllChannels() {
-        synchronized (channels) {
-            channels.clear();
+        synchronized (channelLock) {
+            final Iterator chanIter = channels.iterator();
+            while (chanIter.hasNext()) {
+                chanIter.next();
+                chanIter.remove();
+            }
         }
     }
 
@@ -437,7 +444,7 @@ public class Socket {
     }
 
     private void triggerChannelError() {
-        synchronized (channels) {
+        synchronized (channelLock) {
             for (final Channel channel : channels) {
                 channel.trigger(ChannelEvent.ERROR.getPhxEvent(), null);
             }


### PR DESCRIPTION
As we iterate through the channels in the web socket listener's `onMessage` we could potentially trigger a `phx_close` event which would remove the channel while iterating on the same thread causing a `ConcurrentModificationException`.

I made a dedicated object lock `channelLock` and also wrapped the `toString()` method in the lock.